### PR TITLE
Fix password prompt on Mac

### DIFF
--- a/darwin/dmg/.uninstall.tool
+++ b/darwin/dmg/.uninstall.tool
@@ -53,7 +53,7 @@ echo ""
 # Use AppleScript so we can use a graphical `sudo` prompt.
 # This way, people can enter the username they wish to use
 # for sudo, and it is more Apple-like.
-osascript -e "do shell script \"/bin/rm -Rf ${my_files[*]}\" with administrator privileges with title nanobox"
+osascript -e "do shell script \"/bin/rm -Rf ${my_files[*]}\" with administrator privileges"
 
 # Verify that the uninstall succeeded by checking whether every file
 # we meant to remove is actually removed.


### PR DESCRIPTION
Trying to run the script gives this error:

```
The uninstallation process requires administrative privileges
because some of the installed files cannot be removed by a
normal user. You may now be prompted for a password...

107:114: syntax error: Expected “given”, “with”, “without”, other parameter name, etc. but found identifier. (-2741)
An error must have occurred since a file that was supposed to be
removed still exists: /opt/nanobox
```

Removing the `with title nanobox` from the script fixes it.
